### PR TITLE
Optimize code generation with parallel file writing

### DIFF
--- a/cmd/goa/gen.go
+++ b/cmd/goa/gen.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"goa.design/goa/v3/codegen"
 	"golang.org/x/tools/go/packages"
@@ -44,7 +45,7 @@ type Generator struct {
 }
 
 // NewGenerator creates a Generator.
-func NewGenerator(cmd string, path, output string) *Generator {
+func NewGenerator(cmd, path, output string, debug bool) *Generator {
 	bin := "goa"
 	if runtime.GOOS == "windows" {
 		bin += ".exe"
@@ -55,7 +56,11 @@ func NewGenerator(cmd string, path, output string) *Generator {
 	{
 		version = 2
 		matched := false
+		startPkgLoad := time.Now()
 		pkgs, _ := packages.Load(&packages.Config{Mode: packages.NeedFiles | packages.NeedModule}, path)
+		if debug {
+			fmt.Fprintf(os.Stderr, "[TIMING]   packages.Load (design files) took %v\n", time.Since(startPkgLoad))
+		}
 		fset := token.NewFileSet()
 		p := regexp.MustCompile(`goa.design/goa/v(\d+)/dsl`)
 		for _, pkg := range pkgs {
@@ -132,6 +137,7 @@ func (g *Generator) Write(_ bool) error {
 			codegen.SimpleImport("sort"),
 			codegen.SimpleImport("strconv"),
 			codegen.SimpleImport("strings"),
+			codegen.SimpleImport("time"),
 			codegen.SimpleImport("goa.design/goa/" + ver + "codegen"),
 			codegen.SimpleImport("goa.design/goa/" + ver + "codegen/generator"),
 			codegen.SimpleImport("goa.design/goa/" + ver + "eval"),
@@ -154,9 +160,10 @@ func (g *Generator) Write(_ bool) error {
 }
 
 // Compile compiles the generator.
-func (g *Generator) Compile() error {
+func (g *Generator) Compile(debug bool) error {
 	// We first need to go get the generated package to make sure that all
 	// dependencies are added to go.sum prior to compiling.
+	startLoad := time.Now()
 	pkgs, err := packages.Load(&packages.Config{Mode: packages.NeedName}, fmt.Sprintf(".%c%s", filepath.Separator, g.tmpDir))
 	if err != nil {
 		return err
@@ -164,13 +171,25 @@ func (g *Generator) Compile() error {
 	if len(pkgs) != 1 {
 		return fmt.Errorf("expected to find one package in %s", g.tmpDir)
 	}
+	if debug {
+		fmt.Fprintf(os.Stderr, "[TIMING]   packages.Load (temp dir) took %v\n", time.Since(startLoad))
+	}
+
 	if !g.hasVendorDirectory {
+		startGet := time.Now()
 		if err := g.runGoCmd("get", pkgs[0].PkgPath); err != nil {
 			return err
 		}
+		if debug {
+			fmt.Fprintf(os.Stderr, "[TIMING]   go get took %v\n", time.Since(startGet))
+		}
 	}
 
+	startBuild := time.Now()
 	err = g.runGoCmd("build", "-o", g.bin)
+	if debug {
+		fmt.Fprintf(os.Stderr, "[TIMING]   go build took %v\n", time.Since(startBuild))
+	}
 
 	// If we're in vendor context we check the error string to see if it's an issue of unsatisfied dependencies
 	if err != nil && g.hasVendorDirectory {
@@ -183,7 +202,7 @@ func (g *Generator) Compile() error {
 }
 
 // Run runs the compiled binary and return the output lines.
-func (g *Generator) Run() ([]string, error) {
+func (g *Generator) Run(debug bool) ([]string, error) {
 	var cmdl string
 	{
 		args := make([]string, len(os.Args)-1)
@@ -210,7 +229,7 @@ func (g *Generator) Run() ([]string, error) {
 		cmdl = fmt.Sprintf("$ %s%s", rawcmd, cmdl)
 	}
 
-	args := []string{"--version=" + strconv.Itoa(g.DesignVersion), "--output=" + g.Output, "--cmd=" + cmdl}
+	args := []string{"--version=" + strconv.Itoa(g.DesignVersion), "--output=" + g.Output, "--cmd=" + cmdl, "--debug=" + strconv.FormatBool(debug)}
 	cmd := exec.Command(filepath.Join(g.tmpDir, g.bin), args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -291,6 +310,7 @@ const mainT = `func main() {
 		out     = flag.String("output", "", "")
 		version = flag.String("version", "", "")
 		cmdl    = flag.String("cmd", "", "")
+		debug   = flag.Bool("debug", false, "")
 		ver int
 	)
 	{
@@ -311,15 +331,31 @@ const mainT = `func main() {
 		ver = v
 	}
 
+	startBinary := time.Now()
+	if *debug {
+		fmt.Fprintf(os.Stderr, "[TIMING]   [binary] Starting generated binary execution\n")
+	}
+
 	if ver > goa.Major {
 		fail("cannot run goa %s on design using goa v%s\n", goa.Version(), *version)
 	}
+
+	startCheckErrors := time.Now()
 	if err := eval.Context.Errors; err != nil {
 		fail(err.Error())
 	}
+	if *debug {
+		fmt.Fprintf(os.Stderr, "[TIMING]   [binary] Check eval.Context.Errors took %v\n", time.Since(startCheckErrors))
+	}
+
+	startRunDSL := time.Now()
 	if err := eval.RunDSL(); err != nil {
 		fail(err.Error())
 	}
+	if *debug {
+		fmt.Fprintf(os.Stderr, "[TIMING]   [binary] eval.RunDSL() took %v\n", time.Since(startRunDSL))
+	}
+
 {{- range .CleanupDirs }}
 	if err := os.RemoveAll({{ printf "%q" . }}); err != nil {
 		fail(err.Error())
@@ -328,11 +364,16 @@ const mainT = `func main() {
 {{- if gt .DesignVersion 2 }}
 	codegen.DesignVersion = ver
 {{- end }}
-	outputs, err := generator.Generate(*out, {{ printf "%q" .Command }})
+
+	startGenerate := time.Now()
+	outputs, err := generator.Generate(*out, {{ printf "%q" .Command }}, *debug)
 	if err != nil {
 		fail(err.Error())
 	}
-
+	if *debug {
+		fmt.Fprintf(os.Stderr, "[TIMING]   [binary] generator.Generate() took %v\n", time.Since(startGenerate))
+		fmt.Fprintf(os.Stderr, "[TIMING]   [binary] Total binary execution took %v\n", time.Since(startBinary))
+	}
 	fmt.Println(strings.Join(outputs, "\n"))
 }
 

--- a/cmd/goa/main.go
+++ b/cmd/goa/main.go
@@ -5,6 +5,7 @@ import (
 	"go/build"
 	"os"
 	"strings"
+	"time"
 
 	"flag"
 
@@ -76,29 +77,55 @@ var (
 
 func generate(cmd, path, output string, debug bool) error {
 	var (
-		files []string
-		err   error
-		tmp   *Generator
+		files                                                            []string
+		err                                                              error
+		tmp                                                              *Generator
+		startTotal, startImport, startNewGen, startWrite, startCompile, startRun time.Time
 	)
 
+	startTotal = time.Now()
+	if debug {
+		fmt.Fprintf(os.Stderr, "[TIMING] Starting goa generation\n")
+	}
+
+	startImport = time.Now()
 	if _, err = build.Import(path, ".", 0); err != nil {
 		goto fail
 	}
+	if debug {
+		fmt.Fprintf(os.Stderr, "[TIMING] build.Import took %v\n", time.Since(startImport))
+	}
 
-	tmp = NewGenerator(cmd, path, output)
+	startNewGen = time.Now()
+	tmp = NewGenerator(cmd, path, output, debug)
+	if debug {
+		fmt.Fprintf(os.Stderr, "[TIMING] NewGenerator took %v\n", time.Since(startNewGen))
+	}
 
+	startWrite = time.Now()
 	if err = tmp.Write(debug); err != nil {
 		goto fail
 	}
-
-	if err = tmp.Compile(); err != nil {
-		goto fail
+	if debug {
+		fmt.Fprintf(os.Stderr, "[TIMING] Write (generate main.go) took %v\n", time.Since(startWrite))
 	}
 
-	if files, err = tmp.Run(); err != nil {
+	startCompile = time.Now()
+	if err = tmp.Compile(debug); err != nil {
 		goto fail
 	}
+	if debug {
+		fmt.Fprintf(os.Stderr, "[TIMING] Compile (go get + go build) took %v\n", time.Since(startCompile))
+	}
 
+	startRun = time.Now()
+	if files, err = tmp.Run(debug); err != nil {
+		goto fail
+	}
+	if debug {
+		fmt.Fprintf(os.Stderr, "[TIMING] Run (execute binary) took %v\n", time.Since(startRun))
+		fmt.Fprintf(os.Stderr, "[TIMING] Total generation time: %v\n", time.Since(startTotal))
+	}
 	fmt.Println(strings.Join(files, "\n"))
 	if !debug {
 		tmp.Remove()

--- a/codegen/generator/generate.go
+++ b/codegen/generator/generate.go
@@ -1,9 +1,13 @@
 package generator
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
+	"sync"
+	"time"
 
 	"goa.design/goa/v3/codegen"
 	"goa.design/goa/v3/eval"
@@ -11,20 +15,30 @@ import (
 )
 
 // Generate runs the code generation algorithms.
-func Generate(dir, cmd string) (outputs []string, err1 error) {
+func Generate(dir, cmd string, debug bool) (outputs []string, err1 error) {
+	startGenerate := time.Now()
+	if debug {
+		fmt.Fprintf(os.Stderr, "[TIMING]     [generate] Starting generator.Generate()\n")
+	}
+
 	// 1. Compute design roots.
 	var roots []eval.Root
 	{
+		start := time.Now()
 		rs, err := eval.Context.Roots()
 		if err != nil {
 			return nil, err
 		}
 		roots = rs
+		if debug {
+			fmt.Fprintf(os.Stderr, "[TIMING]     [generate] Stage 1: Compute design roots took %v\n", time.Since(start))
+		}
 	}
 
 	// 2. Compute "gen" package import path.
 	var genpkg string
 	{
+		start := time.Now()
 		base, err := filepath.Abs(dir)
 		if err != nil {
 			return nil, err
@@ -52,59 +66,163 @@ func Generate(dir, cmd string) (outputs []string, err1 error) {
 			return nil, err
 		}
 
+		startPkgLoad := time.Now()
 		pkgs, err := packages.Load(&packages.Config{Mode: packages.NeedName}, path)
 		if err != nil {
 			return nil, err
 		}
 		genpkg = pkgs[0].PkgPath
+		if debug {
+			fmt.Fprintf(os.Stderr, "[TIMING]     [generate]   packages.Load took %v\n", time.Since(startPkgLoad))
+			fmt.Fprintf(os.Stderr, "[TIMING]     [generate] Stage 2: Compute gen package import path took %v\n", time.Since(start))
+		}
 	}
 
 	// 3. Retrieve goa generators for given command.
 	var genfuncs []Genfunc
 	{
+		start := time.Now()
 		gs, err := Generators(cmd)
 		if err != nil {
 			return nil, err
 		}
 		genfuncs = gs
+		if debug {
+			fmt.Fprintf(os.Stderr, "[TIMING]     [generate] Stage 3: Retrieve goa generators took %v (%d generators)\n", time.Since(start), len(genfuncs))
+		}
 	}
 
 	// 4. Run the code pre generation plugins.
-	err := codegen.RunPluginsPrepare(cmd, genpkg, roots)
-	if err != nil {
-		return nil, err
+	{
+		start := time.Now()
+		err := codegen.RunPluginsPrepare(cmd, genpkg, roots)
+		if err != nil {
+			return nil, err
+		}
+		if debug {
+			fmt.Fprintf(os.Stderr, "[TIMING]     [generate] Stage 4: Run pre-generation plugins took %v\n", time.Since(start))
+		}
 	}
 
 	// 5. Generate initial set of files produced by goa code generators.
+	// NOTE: Parallelization causes infinite recursion in AsObject() for circular type references
 	var genfiles []*codegen.File
-	for _, gen := range genfuncs {
-		fs, err := gen(genpkg, roots)
-		if err != nil {
-			return nil, err
+	{
+		start := time.Now()
+		for i, gen := range genfuncs {
+			genStart := time.Now()
+			fs, err := gen(genpkg, roots)
+			if err != nil {
+				return nil, err
+			}
+			genfiles = append(genfiles, fs...)
+			if debug {
+				fmt.Fprintf(os.Stderr, "[TIMING]     [generate]   Generator %d produced %d files in %v\n", i, len(fs), time.Since(genStart))
+			}
 		}
-		genfiles = append(genfiles, fs...)
+		if debug {
+			fmt.Fprintf(os.Stderr, "[TIMING]     [generate] Stage 5: Generate initial files took %v (total %d files)\n", time.Since(start), len(genfiles))
+		}
 	}
 
 	// 6. Run the code generation plugins.
-	genfiles, err = codegen.RunPlugins(cmd, genpkg, roots, genfiles)
-	if err != nil {
-		return nil, err
-	}
-
-	// 7. Write the files.
-	written := make(map[string]struct{})
-	for _, f := range genfiles {
-		filename, err := f.Render(dir)
+	{
+		start := time.Now()
+		var err error
+		genfiles, err = codegen.RunPlugins(cmd, genpkg, roots, genfiles)
 		if err != nil {
 			return nil, err
 		}
-		if filename != "" {
-			written[filename] = struct{}{}
+		if debug {
+			fmt.Fprintf(os.Stderr, "[TIMING]     [generate] Stage 6: Run post-generation plugins took %v (now %d files)\n", time.Since(start), len(genfiles))
+		}
+	}
+
+	// 7. Write the files (in parallel).
+	written := make(map[string]struct{})
+	{
+		start := time.Now()
+		numWorkers := runtime.NumCPU()
+		if debug {
+			fmt.Fprintf(os.Stderr, "[TIMING]     [generate] Stage 7: Starting parallel file writing with %d workers\n", numWorkers)
+		}
+
+		// Channel for work items
+		type workItem struct {
+			index int
+			file  *codegen.File
+		}
+		workChan := make(chan workItem, len(genfiles))
+
+		// Channel for results
+		type result struct {
+			index    int
+			filename string
+			duration time.Duration
+			err      error
+		}
+		resultChan := make(chan result, len(genfiles))
+
+		// Start worker pool
+		var wg sync.WaitGroup
+		for i := 0; i < numWorkers; i++ {
+			wg.Add(1)
+			go func(workerID int) {
+				defer wg.Done()
+				for work := range workChan {
+					renderStart := time.Now()
+					filename, err := work.file.Render(dir)
+					resultChan <- result{
+						index:    work.index,
+						filename: filename,
+						duration: time.Since(renderStart),
+						err:      err,
+					}
+				}
+			}(i)
+		}
+
+		// Send all files to work channel
+		for i, f := range genfiles {
+			workChan <- workItem{index: i, file: f}
+		}
+		close(workChan)
+
+		// Wait for all workers to finish in a separate goroutine
+		go func() {
+			wg.Wait()
+			close(resultChan)
+		}()
+
+		// Collect results
+		var firstErr error
+		slowRenders := 0
+		for res := range resultChan {
+			if res.err != nil && firstErr == nil {
+				firstErr = res.err
+			}
+			if res.filename != "" {
+				written[res.filename] = struct{}{}
+			}
+			// Only log slow renders (>100ms) to avoid spam
+			if debug && res.duration > 100*time.Millisecond {
+				fmt.Fprintf(os.Stderr, "[TIMING]     [generate]   File %d (%s) render took %v\n", res.index, res.filename, res.duration)
+				slowRenders++
+			}
+		}
+
+		if firstErr != nil {
+			return nil, firstErr
+		}
+
+		if debug {
+			fmt.Fprintf(os.Stderr, "[TIMING]     [generate] Stage 7: Write files took %v (%d files written, %d slow renders)\n", time.Since(start), len(written), slowRenders)
 		}
 	}
 
 	// 8. Compute all output filenames.
 	{
+		start := time.Now()
 		outputs = make([]string, len(written))
 		cwd, err := os.Getwd()
 		if err != nil {
@@ -119,8 +237,14 @@ func Generate(dir, cmd string) (outputs []string, err1 error) {
 			outputs[i] = rel
 			i++
 		}
+		if debug {
+			fmt.Fprintf(os.Stderr, "[TIMING]     [generate] Stage 8: Compute output filenames took %v\n", time.Since(start))
+		}
 	}
 	sort.Strings(outputs)
 
+	if debug {
+		fmt.Fprintf(os.Stderr, "[TIMING]     [generate] Total generator.Generate() took %v\n", time.Since(startGenerate))
+	}
 	return outputs, nil
 }

--- a/expr/random.go
+++ b/expr/random.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"net"
 	"strings"
+	"sync"
 
 	"github.com/manveru/faker"
 )
@@ -66,10 +67,13 @@ func NewRandom(seed string) *ExampleGenerator {
 type ExampleGenerator struct {
 	Randomizer
 	seen map[string]*any
+	mu   sync.RWMutex
 }
 
 // PreviouslySeen returns the previously seen value for a given ID
 func (r *ExampleGenerator) PreviouslySeen(typeID string) (*any, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	if r.seen == nil {
 		return nil, false
 	}
@@ -79,6 +83,8 @@ func (r *ExampleGenerator) PreviouslySeen(typeID string) (*any, bool) {
 
 // HaveSeen stores the seen value in the randomizer, for reuse later
 func (r *ExampleGenerator) HaveSeen(typeID string, val *any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if r.seen == nil {
 		r.seen = make(map[string]*any)
 	}


### PR DESCRIPTION
tl;dr: make codegen much faster through parallel writing of files

As a recap, the generation process has several stages:

1. **Compile temporary binary**: Goa creates a temporary Go program that imports the design package (which triggers package initialization and DSL execution via blank import)
2. **Execute binary**: The binary runs through multiple phases:
   - Package initialization (runs DSL definitions)
   - `eval.RunDSL()` - processes the DSL in 4 phases (execute, prepare, validate, finalize)
   - `generator.Generate()` - produces the actual Go files

Measuring codegen for the incident-io codebase on 3,036 generated files:

**Total time: 61 seconds**

Breakdown:
- build.Import: 117ms
- NewGenerator (packages.Load): 52ms
- Write (generate main.go): 14ms
- Compile (go get + go build): 3.6s
  - packages.Load: 47ms
  - go get: 514ms
  - go build: 3.0s
- **Run (execute binary): 52.2s** ⚠️ 85% of total time
  - Check eval.Context.Errors: <1ms
  - eval.RunDSL(): 105ms
  - **generator.Generate(): 51.6s** ⚠️ Main bottleneck
    - Stage 1 (Compute design roots): <1ms
    - Stage 2 (Compute gen package): 33ms
    - Stage 3 (Retrieve generators): <1ms
    - Stage 4 (Pre-generation plugins): <1ms
    - **Stage 5 (Generate files): 26.2s** (3 generators, sequential)
      - Generator 0: 7.2s → 1,438 files
      - Generator 1: 18.8s → 1,594 files - Generator 2: 0.2s → 4 files
    - Stage 6 (Post-generation plugins): <1ms
    - **Stage 7 (Write files): 32.1s** ⚠️ Biggest bottleneck (52% of generation)
    - Stage 8 (Compute filenames): 2ms

This commit tries optimising the biggest stage of this process and changes file rendering from sequential loop to parallel worker pool:

```go
// Before: Sequential (32.1s for 3,036 files)
for _, f := range genfiles {
    filename, err := f.Render(dir)
    // ...
}

// After: Parallel with runtime.NumCPU() workers
numWorkers := runtime.NumCPU()
// Worker pool processes files concurrently
```

Which changed execution time from **61 seconds total** to **34 seconds total**, for an overall speedup of 1.8x.

While here, I also tried parallelising Stage 5 (generator functions) but hit infinite recursion in `AsObject()` when handling circular type references concurrently. This is where I'd go for the next biggest speed-up.